### PR TITLE
Fix pack name select prompt on new platform view

### DIFF
--- a/app/views/design/platforms/_platform_details_content.html.erb
+++ b/app/views/design/platforms/_platform_details_content.html.erb
@@ -24,7 +24,7 @@
       <div class="control-group">
         <% a = attributes_meta.detect { |m| m.attributeName == 'pack' } %>
         <%= c.label :pack, a.description + (a.isMandatory ? '*' : ''), :class => 'control-label' %>
-        <div class="controls"><%= c.select :pack, grouped_options_for_select(packs[first_source], nil, :prompt => 'Please select'), {}, :id => 'pack_select', :required => true %></div>
+        <div class="controls"><%= c.select :pack, grouped_options_for_select(packs[first_source], nil), { :prompt => 'Please select' }, :id => 'pack_select', :required => true %></div>
       </div>
 
       <div class="control-group">


### PR DESCRIPTION
Set the 'Please select' prompt as the default option for the pack name
select element, preventing the prompt from being selected as a valid
option.