### PR TITLE
Strengthen the code by adding "sanitizing" of attribute content while…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -26,7 +26,7 @@ module ApplicationHelper
                 :history                => 'history',
                 :release                => 'tag',
                 :deployment             => 'cloud-upload',
-                :procedure              => 'wrench',
+                :deployment             => 'cloud-upload',
                 :compute                => 'server'}
 
   GENERAL_SITE_LINKS = [{:label => 'Get help',         :icon => 'comments',  :url => Settings.support_chat_url},
@@ -1173,7 +1173,7 @@ module ApplicationHelper
       if attr_value.blank?
         result << '&nbsp;'
       else
-        result << %(<pre class="changed">#{json && attr_value.present? ? JSON.pretty_unparse(attr_value) : attr_value}</pre>)
+        result << %(<pre class="changed">#{h(json && attr_value.present? ? JSON.pretty_unparse(attr_value) : attr_value)}</pre>)
       end
       if json && base_value.present?
         begin
@@ -1182,7 +1182,7 @@ module ApplicationHelper
           json = false
         end
       end
-      result << %(<pre class="original hide">#{json && base_value.present? ? JSON.pretty_unparse(base_value) : base_value}</pre>)
+      result << %(<pre class="original hide">#{h(json && base_value.present? ? JSON.pretty_unparse(base_value) : base_value)}</pre>)
       result << '</dd>'
     end
     result << '</dl>'

--- a/app/models/cms/rfc_relation.rb
+++ b/app/models/cms/rfc_relation.rb
@@ -34,7 +34,13 @@ class Cms::RfcRelation < Cms::Relation
   end
 
   def ci_hash
-    return @ci_hash if @ci_hash
-    @ci_hash = comments.present? ? JSON.parse(comments) : {}
+    unless @ci_hash
+      begin
+        @ci_hash = comments.present? ? JSON.parse(comments) : {}
+      rescue Exception => e
+        @ci_hash = {}
+      end
+    end
+    return @ci_hash
   end
 end

--- a/app/views/base/shared/_ci_diff_list.html.erb
+++ b/app/views/base/shared/_ci_diff_list.html.erb
@@ -35,8 +35,8 @@
             <%= highlight(md_attribute ? md_attribute.description : attr) %>
             <%= icon(owner_map.attributes[md_attribute.attributeName] == owner_value ? 'lock' : 'unlock') if owner_map %>
           </td>
-          <td><pre class="changed"><%= json && value.present? ? JSON.pretty_unparse(JSON.parse(value)) : value %></pre></td>
-          <td><pre class="original muted"><%= json && base_value.present? ? JSON.pretty_unparse(JSON.parse(base_value)) : base_value %></pre></td>
+          <td><pre class="changed"><%= h(json && value.present? ? JSON.pretty_unparse(JSON.parse(value)) : value) %></pre></td>
+          <td><pre class="original muted"><%= h(json && base_value.present? ? JSON.pretty_unparse(JSON.parse(base_value)) : base_value) %></pre></td>
         </tr>
       <% end %>
       <% unless changes_only %>

--- a/app/views/base/shared/_ci_history.html.erb
+++ b/app/views/base/shared/_ci_history.html.erb
@@ -79,8 +79,8 @@
              base_value = base_attrs[attr] %>
           <tr class="attribute"><td colspan="2"><%= md_attribute ? md_attribute.description : attr %></td></tr>
           <tr class="diff-container">
-            <td><pre class="changed"><%= json && value.present? ? JSON.pretty_unparse(JSON.parse(value)) : value %></pre></td>
-            <td><pre class="original muted"><%= json && base_value.present? ? JSON.pretty_unparse(JSON.parse(base_value)) : base_value %></pre></td>
+            <td><pre class="changed"><%= h(json && value.present? ? JSON.pretty_unparse(JSON.parse(value)) : value) %></pre></td>
+            <td><pre class="original muted"><%= h(json && base_value.present? ? JSON.pretty_unparse(JSON.parse(base_value)) : base_value) %></pre></td>
           </tr>
         <% end %>
       </table>

--- a/app/views/cms/cis/_attributes.html.erb
+++ b/app/views/cms/cis/_attributes.html.erb
@@ -131,8 +131,8 @@
                   <div class="title">Base Value Diff</div>
                   <% if base_value && base_value != attribute_value %>
                     <% json = data_type == 'hash' || data_type == 'array' || data_type == 'struct' %>
-                    <pre class="changed hide"><%= json && attribute_value.present? ? JSON.pretty_unparse(JSON.parse(attribute_value)) : attribute_value  %></pre>
-                    <pre class="original hide"><%= json && base_value.present? ? JSON.pretty_unparse(JSON.parse(base_value)) : base_value %></pre>
+                    <pre class="changed hide"><%= h(json && attribute_value.present? ? JSON.pretty_unparse(JSON.parse(attribute_value)) : attribute_value) %></pre>
+                    <pre class="original hide"><%= h(json && base_value.present? ? JSON.pretty_unparse(JSON.parse(base_value)) : base_value) %></pre>
                     <pre class="diff hide"></pre>
                   <% else %>
                     no changes

--- a/app/views/cms/rfcs/_rfc.js.erb
+++ b/app/views/cms/rfcs/_rfc.js.erb
@@ -1,4 +1,4 @@
-//if (!window.toggle_rfc_tab) {
+if (!window.toggle_rfc_tab) {
   window.toggle_rfc_tab = function (source, rfcId, tabName) {
     source = $j(source);
     var ul = source.parents(".accordion-toggle").find('.nav'),
@@ -28,4 +28,4 @@
       <% end %>
     }
   };
-//}
+}


### PR DESCRIPTION
… displaying in <PRE> tags for diff purposes.    Some content (i.e. html/xml mark-down) caused javascript errors while rendered in a browser.