### PR TITLE
Fixed the metric context for accurate REST API Calls

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -59,7 +59,7 @@ defaults: &defaults
   cms_site: <%= ENV['CMS_SITE'] || 'http://cmsapi:8080/' %>
   transistor_site: <%= ENV['TRANSISTOR_SITE'] || ENV['CMS_SITE'] || 'http://cmsapi:8080/' %>
   metrics_site: <%= ENV['METRICS_SITE'] || 'http://cmsapi:8080/' %>
-  metrics_context: <%= ENV['METRICS_CONTEXT'] || '/daq-1.0.0' %>
+  metrics_context: <%= ENV['METRICS_CONTEXT'] || '/daq-api-1.0.0' %>
   events_site: <%= ENV['EVENTS_SITE'] || 'http://sensor:8080/' %>
   notifications_site: <%= ENV['NOTIFICATION_SITE'] || 'http://antenna:8080/' %>
   search_site: <%= ENV['SEARCH_SITE'] || 'http://search:9200/' %>


### PR DESCRIPTION
Calls to display metrics are getting a 404 error because of a typo in the settings. 